### PR TITLE
Ur readability fix

### DIFF
--- a/wiki/Gameplay/Unstable_rate/en.md
+++ b/wiki/Gameplay/Unstable_rate/en.md
@@ -12,7 +12,7 @@ tags:
 
 # Unstable rate
 
-**Unstable rate** (***UR***) is a measurement of variation of hit errors<!-- TODO: link --> throughout a play. It is calculated as multiplied by 10 [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of hit errors in miliiseconds. A lower UR indicates that the player's hits have more similar errors, while a higher UR indicates they are more spread apart.
+**Unstable rate** (***UR***) is a measurement of variation of hit errors<!-- TODO: link --> throughout a play. It is calculated as the [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of hit errors in miliiseconds, multiplied by 10. A lower UR indicates that the player's hits have more similar errors, while a higher UR indicates they are more spread apart.
 
 Players specialising in high [accuracy](/wiki/Gameplay/Accuracy) often achieve URs that are significantly below what is required to get an [SS](/wiki/Gameplay/Grade). Unstable rate can be a particularly useful metric to help judge these scores in finer detail than regular [judgements](/wiki/Gameplay/Judgement).
 

--- a/wiki/Gameplay/Unstable_rate/en.md
+++ b/wiki/Gameplay/Unstable_rate/en.md
@@ -12,7 +12,7 @@ tags:
 
 # Unstable rate
 
-**Unstable rate** (***UR***) is a measurement of variation of hit errors<!-- TODO: link --> throughout a play. It is calculated as the [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of hit errors in miliiseconds multiplied by 10. A lower UR indicates that the player's hits have more similar errors, while a higher UR indicates they are more spread apart.
+**Unstable rate** (***UR***) is a measurement of variation of hit errors<!-- TODO: link --> throughout a play. It is calculated as the multiplied by 10 [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of hit errors in miliiseconds. A lower UR indicates that the player's hits have more similar errors, while a higher UR indicates they are more spread apart.
 
 Players specialising in high [accuracy](/wiki/Gameplay/Accuracy) often achieve URs that are significantly below what is required to get an [SS](/wiki/Gameplay/Grade). Unstable rate can be a particularly useful metric to help judge these scores in finer detail than regular [judgements](/wiki/Gameplay/Judgement).
 

--- a/wiki/Gameplay/Unstable_rate/en.md
+++ b/wiki/Gameplay/Unstable_rate/en.md
@@ -12,7 +12,7 @@ tags:
 
 # Unstable rate
 
-**Unstable rate** (***UR***) is a measurement of variation of hit errors<!-- TODO: link --> throughout a play. It is calculated as the multiplied by 10 [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of hit errors in miliiseconds. A lower UR indicates that the player's hits have more similar errors, while a higher UR indicates they are more spread apart.
+**Unstable rate** (***UR***) is a measurement of variation of hit errors<!-- TODO: link --> throughout a play. It is calculated as multiplied by 10 [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of hit errors in miliiseconds. A lower UR indicates that the player's hits have more similar errors, while a higher UR indicates they are more spread apart.
 
 Players specialising in high [accuracy](/wiki/Gameplay/Accuracy) often achieve URs that are significantly below what is required to get an [SS](/wiki/Gameplay/Grade). Unstable rate can be a particularly useful metric to help judge these scores in finer detail than regular [judgements](/wiki/Gameplay/Judgement).
 

--- a/wiki/Gameplay/Unstable_rate/en.md
+++ b/wiki/Gameplay/Unstable_rate/en.md
@@ -12,7 +12,7 @@ tags:
 
 # Unstable rate
 
-**Unstable rate** (***UR***) is a measurement of variation of hit errors<!-- TODO: link --> throughout a play. It is calculated as the [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of hit errors, displayed in tenths of a millisecond. A lower UR indicates that the player's hits have more similar errors, while a higher UR indicates they are more spread apart.
+**Unstable rate** (***UR***) is a measurement of variation of hit errors<!-- TODO: link --> throughout a play. It is calculated as the [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) of hit errors in miliiseconds multiplied by 10. A lower UR indicates that the player's hits have more similar errors, while a higher UR indicates they are more spread apart.
 
 Players specialising in high [accuracy](/wiki/Gameplay/Accuracy) often achieve URs that are significantly below what is required to get an [SS](/wiki/Gameplay/Grade). Unstable rate can be a particularly useful metric to help judge these scores in finer detail than regular [judgements](/wiki/Gameplay/Judgement).
 


### PR DESCRIPTION
<!-- 
  - Use [x] to complete the items
  - Remove the items unrelated to your work
  - Add any relevant information you consider useful
  - If there are no reviewers for your language, please mention it explicitly
-->
In my opinion current version of the page does not clearly reflects its meaning. I think its better to explicitly say that SD is multiplied by ten instead of saying "tenths of miliseconds" 

## Self-check

- [x] The changes are tested against the [contribution checklist](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#self-check)
- [ ] *(translations only)* The changes are reviewed on GitHub [by a fluent speaker](https://osu.ppy.sh/wiki/osu!_wiki/Contribution_guide#review)